### PR TITLE
Initial bylaws commit

### DIFF
--- a/bylaws.rst
+++ b/bylaws.rst
@@ -1,50 +1,56 @@
-LUG Rules
-=========
+LUG Bylaws
+==========
 
 Preamble
 --------
-This is a set of rules for the Oregon State University Linux Users Group. These
+This is a set of bylaws for the Oregon State University Linux Users Group. These
 are not set in stone and are in fact meant to be dynamic; adapting to the needs
-of the community as they change. These rules are seperate from our constitution
+of the community as they change. These bylaws are seperate from our constitution
 (which is also in this repository) but ought to be enforced by the OSU Linux
 Users Group community.
 
-For information on contributing to the set of rules see the `Contributing`
+For information on contributing to the set of bylaws see the `Contributing`
 section below.
 
-Rules
+Bylaws
 -----
-#. There should be a maximum of one bot in the irc channel (#osu-lug,
-   irc.freenode.net) at any time.
-#. Any malicious (i.e., 'black hat') material shared in the official
-   OSU LUG IRC Channels should be presented in an academic or educational
-   context. We do not encourage the use of malicious exploits under any
-   circumstances.
+* There should be a maximum of one bot in the irc channel (#osu-lug,
+  irc.freenode.net) at any time.
+* Any malicious (i.e., 'black hat') material shared in the official
+  OSU LUG IRC Channels should be presented in an academic or educational
+  context. We do not encourage the use of malicious exploits under any
+  circumstances.
 
 Contributing
 ------------
-How to propose a rule:
+How to propose a bylaw:
 
 #. Have a GitHub account.
 #. Fork this repository into your own personal GitHub account.
 #. Edit this file to modify the ruleset.
 #. Commit this change with a commit message explaining the following:
-    - What the rule is.
-    - Why the rule was put in place.
+    - What the proposed bylaw is.
+    - Why the bylaw was put in place.
     - Your irc handle in #osu-lug and/or your 'real name'.
 #. Create a Pull Request to merge your version of this repository into the
    master branch of the original repository. DO NOT MERGE THE PULL REQUEST.
 
 A pull request into master can only be merged with the approving comment (+1)
-of LUG two officers **and** three active LUG members. The final merge into master must
-be done by an officer of LUG.
+of the following individuals:
+
+* The OSU LUG President.
+* Two officers.
+* Three active LUG members (regularly attend meetings or communicate in the
+  #osu-lug IRC channel.
+
+The final merge into master must be done by an officer of LUG.
 
 Any comment for or against the change in the comments of the pull request must
 include a reason for the support or non-support. Any -1 comments should either
 be fixed by the individual making the pull request or addressed by the
 individual making the pull request with a WONTFIX response and reason. It is
 the responsibility of the voting population to give feedback for improvement if
-a rule proposition; active participation is necessary for this system to work.
+a bylaw proposition; active participation is necessary for this system to work.
 All comments must include the GitHub user's irc handle in #osu-lug if different
 from their github handle.
 

--- a/rules.rst
+++ b/rules.rst
@@ -13,7 +13,7 @@ section below.
 
 Rules
 -----
-- There should be a maximum of one bot in the irc channel (#osu-lug,
+1. There should be a maximum of one bot in the irc channel (#osu-lug,
   irc.freenode.net) at any time. 
 
 Contributing
@@ -35,8 +35,12 @@ be done by an officer of LUG.
 
 Any comment for or against the change in the comments of the pull request must
 include a reason for the support or non-support. Any -1 comments should either
-be fixed or addressed with a WONTFIX response. All comments must include the
-GitHub user's irc handle in #osu-lug.
+be fixed by the individual making the pull request or addressed by the
+individual making the pull request with a WONTFIX response and reason. It is
+the responsibility of the voting population to give feedback for improvement if
+a rule proposition; active participation is necessary for this system to work.
+All comments must include the GitHub user's irc handle in #osu-lug if different
+from their github handle.
 
 Any part of this document can be changed with the above process, including the
 above process, however alterations to the above process must pass by the

--- a/rules.rst
+++ b/rules.rst
@@ -5,32 +5,38 @@ Preamble
 --------
 This is a set of rules for the Oregon State University Linux Users Group. These
 are not set in stone and are in fact meant to be dynamic; adapting to the needs
-of the community as they change. These rules are unique from our constitution
-(which is also in this repository) by still enforced by the community.
+of the community as they change. These rules are seperate from our constitution
+(which is also in this repository) but ought to be enforced by the OSU Linux
+Users Groupcommunity.
 
 For information on contributing to the set of rules see the `Contributing`
 section below.
 
 Rules
 -----
-1. There should be a maximum of one bot in the irc channel (#osu-lug,
-  irc.freenode.net) at any time. 
+#. There should be a maximum of one bot in the irc channel (#osu-lug,
+   irc.freenode.net) at any time.
+#. Any malicious or (i.e., 'black hat') material shared in the official
+   OSU LUG IRC Channels should be presented in an academic or educational
+   context. We do not encourage the use of malicious exploits under any
+   circumstances.
 
 Contributing
 ------------
 How to propose a rule:
-0. Have a GitHub account.
-1. Fork this repository into your own personal GitHub account.
-2. Edit this file to either add/subtract/modify a rule.
-3. Commit this change with an explanative message including:
+
+#. Have a GitHub account.
+#. Fork this repository into your own personal GitHub account.
+#. Edit this file to modify the ruleset.
+#. Commit this change with a commit message explaining the following:
     - What the rule is.
     - Why the rule was put in place.
-    - Your irc handle in #osu-lug
-4. Create a Pull Request to merge your version of this repository into the
-   master branch of the original repository. DO NOT MERGE THE PULL REQUEST YET.
+    - Your irc handle in #osu-lug and/or your 'real name'.
+#. Create a Pull Request to merge your version of this repository into the
+   master branch of the original repository. DO NOT MERGE THE PULL REQUEST.
 
 A pull request into master can only be merged with the approving comment (+1)
-of LUG two officers and six active LUG members. The final merge into master must
+of LUG two officers **and** three active LUG members. The final merge into master must
 be done by an officer of LUG.
 
 Any comment for or against the change in the comments of the pull request must

--- a/rules.rst
+++ b/rules.rst
@@ -1,0 +1,43 @@
+LUG Rules
+=========
+
+Preamble
+--------
+This is a set of rules for the Oregon State University Linux Users Group. These
+are not set in stone and are in fact meant to be dynamic; adapting to the needs
+of the community as they change. These rules are unique from our constitution
+(which is also in this repository) by still enforced by the community.
+
+For information on contributing to the set of rules see the `Contributing`
+section below.
+
+Rules
+-----
+- There should be a maximum of one bot in the irc channel (#osu-lug,
+  irc.freenode.net) at any time. 
+
+Contributing
+------------
+How to propose a rule:
+0. Have a GitHub account.
+1. Fork this repository into your own personal GitHub account.
+2. Edit this file to either add/subtract/modify a rule.
+3. Commit this change with an explanative message including:
+    - What the rule is.
+    - Why the rule was put in place.
+    - Your irc handle in #osu-lug
+4. Create a Pull Request to merge your version of this repository into the
+   master branch of the original repository. DO NOT MERGE THE PULL REQUEST YET.
+
+A pull request into master can only be merged with the approving comment (+1)
+of LUG two officers and six active LUG members. The final merge into master must
+be done by an officer of LUG.
+
+Any comment for or against the change in the comments of the pull request must
+include a reason for the support or non-support. Any -1 comments should either
+be fixed or addressed with a WONTFIX response. All comments must include the
+GitHub user's irc handle in #osu-lug.
+
+Any part of this document can be changed with the above process, including the
+above process, however alterations to the above process must pass by the
+current process's rules.

--- a/rules.rst
+++ b/rules.rst
@@ -7,7 +7,7 @@ This is a set of rules for the Oregon State University Linux Users Group. These
 are not set in stone and are in fact meant to be dynamic; adapting to the needs
 of the community as they change. These rules are seperate from our constitution
 (which is also in this repository) but ought to be enforced by the OSU Linux
-Users Groupcommunity.
+Users Group community.
 
 For information on contributing to the set of rules see the `Contributing`
 section below.
@@ -16,7 +16,7 @@ Rules
 -----
 #. There should be a maximum of one bot in the irc channel (#osu-lug,
    irc.freenode.net) at any time.
-#. Any malicious or (i.e., 'black hat') material shared in the official
+#. Any malicious (i.e., 'black hat') material shared in the official
    OSU LUG IRC Channels should be presented in an academic or educational
    context. We do not encourage the use of malicious exploits under any
    circumstances.


### PR DESCRIPTION
These rules (and the ideas of rules) spawned from a conversation in
\#osu-lug on January 22, 2015 about how there should only be one bot
in the channel at any time.

rules.rst is are community rules which are  enforced, created, modified,
etc by the LUG community for the LUG community. They are not bylaws nor
are they part of the constitution. They are guidelines set in something
between stone and passing comments.

Pull Requests Welcome.